### PR TITLE
Add KiloNeRF

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A curated list of awesome neural radiance fields papers, inspired by [awesome-co
 - [Neural Sparse Voxel Fields](https://lingjie0206.github.io/papers/NSVF/), Liu et al., NeurIPS 2020 | [github](https://github.com/facebookresearch/NSVF) | [bibtex](./NeRF-and-Beyond.bib#L135-L141) <!---Liu20neurips_sparse_nerf-->
 - [AutoInt: Automatic Integration for Fast Neural Volume Rendering](http://www.computationalimaging.org/publications/automatic-integration/), Lindell et al., Arxiv 2020 | [bibtex](./NeRF-and-Beyond.bib#L127-L133) <!---Lindell20arxiv_AutoInt-->
 - [DONeRF: Towards Real-Time Rendering of Neural Radiance Fields using Depth Oracle Networks](https://depthoraclenerf.github.io/), Neff et al., Arxiv 2021 | [bibtex](./citations/donerf.txt) <!---neff2021donerf-->
+- [KiloNeRF: Speeding up Neural Radiance Fields with Thousands of Tiny MLPs ](https://arxiv.org/abs/2103.13744), Reiser et al., Arxiv 2021 | [bibtex](./citations/kilonerf.txt) <!---reiser2021kilonerf-->
 
 #### Unconstrained Images
 - [NeRF in the Wild: Neural Radiance Fields for Unconstrained Photo Collections](https://nerf-w.github.io/), Martin-Brualla et al., Arxiv 2020 | [bibtex](./NeRF-and-Beyond.bib#L152-L158) <!---MartinBrualla20arxiv_nerfw-->

--- a/citations/kilonerf.txt
+++ b/citations/kilonerf.txt
@@ -1,0 +1,8 @@
+@misc{reiser2021kilonerf,
+      title={KiloNeRF: Speeding up Neural Radiance Fields with Thousands of Tiny MLPs}, 
+      author={Christian Reiser and Songyou Peng and Yiyi Liao and Andreas Geiger},
+      year={2021},
+      eprint={2103.13744},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}


### PR DESCRIPTION
KiloNeRF: Speeding up Neural Radiance Fields with Thousands of Tiny MLPs
by _Christian Reiser_, _Songyou Peng_, _Yiyi Liao_, _Andreas Geiger_ 

NeRF utilizing thousands of tiny MLPs instead of one single large MLP.
