### PR TITLE
Add PlenOctrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A curated list of awesome neural radiance fields papers, inspired by [awesome-co
 - [Neural Sparse Voxel Fields](https://lingjie0206.github.io/papers/NSVF/), Liu et al., NeurIPS 2020 | [github](https://github.com/facebookresearch/NSVF) | [bibtex](./NeRF-and-Beyond.bib#L135-L141) <!---Liu20neurips_sparse_nerf-->
 - [AutoInt: Automatic Integration for Fast Neural Volume Rendering](http://www.computationalimaging.org/publications/automatic-integration/), Lindell et al., Arxiv 2020 | [bibtex](./NeRF-and-Beyond.bib#L127-L133) <!---Lindell20arxiv_AutoInt-->
 - [DONeRF: Towards Real-Time Rendering of Neural Radiance Fields using Depth Oracle Networks](https://depthoraclenerf.github.io/), Neff et al., Arxiv 2021 | [bibtex](./citations/donerf.txt) <!---neff2021donerf-->
+- [PlenOctrees for Real-time Rendering of Neural Radiance Fields](https://alexyu.net/plenoctrees/), Yu et al., Arxiv 2021 | [github](https://github.com/sxyu/volrend) | [bibtex](./citations/plenoctrees.txt) <!---yu2021plenoctrees-->
 
 #### Unconstrained Images
 - [NeRF in the Wild: Neural Radiance Fields for Unconstrained Photo Collections](https://nerf-w.github.io/), Martin-Brualla et al., Arxiv 2020 | [bibtex](./NeRF-and-Beyond.bib#L152-L158) <!---MartinBrualla20arxiv_nerfw-->

--- a/citations/plenoctrees.txt
+++ b/citations/plenoctrees.txt
@@ -1,0 +1,6 @@
+@inproceedings{yu2021plenoctrees,
+      title={PlenOctrees for Real-time Rendering of Neural Radiance Fields},
+      author={Alex Yu and Ruilong Li and Matthew Tancik and Hao Li and Ren Ng and Angjoo Kanazawa},
+      year={2021},
+      booktitle={arXiv},
+}


### PR DESCRIPTION
[PlenOctrees for Real-time Rendering of Neural Radiance Fields](https://alexyu.net/plenoctrees/)
by _Alex Yu_, _Ruilong Li_, _Matthew Tancik_, _Hao Li_, _Ren Ng_, _Angjoo Kanazawa_ 

A method to render Neural Radiance Fields (NeRFs) in real time using PlenOctrees, an octree-based 3D representation which supports view-dependent effects.
