### PR TITLE
add pix2nerf and ICARUS

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A curated list of awesome neural radiance fields papers, inspired by [awesome-co
 #### Faster Training
 - [Depth-supervised NeRF: Fewer Views and Faster Training for Free](https://arxiv.org/pdf/2107.02791.pdf), Deng et al., Arxiv 2021 | [github](https://github.com/dunbar12138/DSNeRF) | [bibtex](./citations/dsnerf.txt)
 - [Direct Voxel Grid Optimization: Super-fast Convergence for Radiance Fields Reconstruction](https://arxiv.org/abs/2111.11215.pdf), Sun et al., Arxiv 2021 | [github](https://github.com/sunset1995/DirectVoxGO) | [bibtex](./citations/DirectVoxGO.txt) <!---sun2021direct-->
+- [ICARUS: A Lightweight Neural Plenoptic Rendering Architecture](https://arxiv.org/abs/2203.01414), Yu et al., Arxiv 2022 | [bibtex](citations/icarus.txt)
 
 #### Unconstrained Images
 - [NeRF in the Wild: Neural Radiance Fields for Unconstrained Photo Collections](https://nerf-w.github.io/), Martin-Brualla et al., CVPR 2021 | [bibtex](./NeRF-and-Beyond.bib#L152-L158) <!---MartinBrualla20arxiv_nerfw-->
@@ -77,6 +78,7 @@ A curated list of awesome neural radiance fields papers, inspired by [awesome-co
 - [CodeNeRF: Disentangled Neural Radiance Fields for Object Categories](https://sites.google.com/view/wbjang/home/codenerf), Jang et al., ICCV 2021 | [bibtex](./citations/CodeNeRF.txt)
 - [StyleNeRF: A Style-based 3D-Aware Generator for High-resolution Image Synthesis](http://jiataogu.me/style_nerf/), Gu et al., Arxiv 2021 | [bibtex](./citations/stylenerf.txt)
 - [NeRF in the Dark: High Dynamic Range View Synthesis from Noisy Raw Images](https://bmild.github.io/rawnerf/), Ben Mildenhall et al, arXiv 2021 | [bibtex](./citations/rawnerf.txt)
+- [Pix2NeRF: Unsupervised Conditional π-GAN for Single Image to Neural Radiance Fields Translation](https://arxiv.org/abs/2202.13162), L. Gool et al, arXiv 2022 | [bibtex](citations/pix2nerf.txt)
 
 #### Pose Estimation
 - [iNeRF: Inverting Neural Radiance Fields for Pose Estimation](http://yenchenlin.me/inerf/), Yen-Chen et al. IROS 2021 | [bibtex](./NeRF-and-Beyond.bib#L321-L327) <!---YenChen20arxiv_iNeRF-->
@@ -96,7 +98,7 @@ A curated list of awesome neural radiance fields papers, inspired by [awesome-co
 
 #### Compositionality
 - [NeRF++: Analyzing and Improving Neural Radiance Fields](https://arxiv.org/abs/2010.07492), Zhang et al., Arxiv 2020 | [github](https://github.com/Kai-46/nerfplusplus) | [bibtex](./NeRF-and-Beyond.bib#L345-L351) <!---Zhang20arxiv_nerf++-->
-- [GIRAFFE: Representing Scenes as Compositional Generative Neural Feature Fields](https://arxiv.org/abs/2011.12100), Niemeyer et al., CVPR 2021, [bibtex](./NeRF-and-Beyond.bib#L175-L181) <!---Niemeyer20arxiv_GIRAFFE-->
+- [GIRAFFE: Representing Scenes as Compositional Generative Neural Feature Fields](https://arxiv.org/abs/2011.12100), Niemeyer et al., CVPR 2021 | [github](https://github.com/autonomousvision/giraffe) | [bibtex](./NeRF-and-Beyond.bib#L175-L181) <!---Niemeyer20arxiv_GIRAFFE-->
 - [Object-Centric Neural Scene Rendering](https://shellguo.com/osf/), Guo et al., Arxiv 2020 | [bibtex](./NeRF-and-Beyond.bib#L111-L117) <!---Guo20arxiv_OSF-->
 - [Learning Compositional Radiance Fields of Dynamic Human Heads](https://ziyanw1.github.io/hybrid_nerf/), Wang et al., Arxiv 2020 | [bibtex](./citations/hybrid-nerf.txt) <!---Wang20arxiv_hybrid_NeRF-->
 - [Neural Scene Graphs for Dynamic Scenes](https://light.princeton.edu/neural-scene-graphs/), Ost et al., CVPR 2021 | [bibtex](./NeRF-and-Beyond.bib#L353-L358) <!---Ost20arxiv_NeuralSceneGraphs-->

--- a/citations/icarus.txt
+++ b/citations/icarus.txt
@@ -1,0 +1,8 @@
+@misc{rao2022icarus,
+    title={ICARUS: A Lightweight Neural Plenoptic Rendering Architecture},
+    author={Chaolin Rao and Huangjie Yu and Haochuan Wan and Jindong Zhou and Yueyang Zheng and Yu Ma and Anpei Chen and Minye Wu and Binzhe Yuan and Pingqiang Zhou and Xin Lou and Jingyi Yu},
+    year={2022},
+    eprint={2203.01414},
+    archivePrefix={arXiv},
+    primaryClass={cs.AR}
+}

--- a/citations/pix2nerf.txt
+++ b/citations/pix2nerf.txt
@@ -1,0 +1,8 @@
+@misc{cai2022pix2nerf,
+    title={Pix2NeRF: Unsupervised Conditional $π$-GAN for Single Image to Neural Radiance Fields Translation},
+    author={Shengqu Cai and Anton Obukhov and Dengxin Dai and Luc Van Gool},
+    year={2022},
+    eprint={2202.13162},
+    archivePrefix={arXiv},
+    primaryClass={cs.CV}
+}


### PR DESCRIPTION
# Pull requests 

1. add Pix2NeRF: Unsupervised Conditional π-GAN for Single Image to Neural Radiance Fields Translation in **Generalization**
2. add ICARUS: A Lightweight Neural Plenoptic Rendering Architecture in **fast training**
