### PR TITLE
add Block-NERF

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ A curated list of awesome neural radiance fields papers, inspired by [awesome-co
 - [Neural Body: Implicit Neural Representations with Structured Latent Codes for Novel View Synthesis of Dynamic Humans](https://zju3dv.github.io/neuralbody/), Peng et al., CVPR 2021 | [bibtex](citations/neuralbody.txt) <!---Peng20arxiv_neuralbody-->
 - [Neural 3D Video Synthesis](https://neural-3d-video.github.io/), Li et al., Arxiv 2021 | [bibtex](./citations/3d-video.txt)
 - [Dynamic View Synthesis from Dynamic Monocular Video](https://free-view-video.github.io/), Gao et al., ICCV 2021 | [bibtex](./citations/dvs_dmv.txt)
+- [Block-NeRF: Scalable Large Scene Neural View Synthesis](https://waymo.com/research/block-nerf/), Tancik et al., Arxiv 2022 | [bibtex](./citations/Block-NeRF.txt)
 
 #### Generalization
 - [GRAF: Generative Radiance Fields for 3D-Aware Image Synthesis](https://arxiv.org/abs/2007.02442), Schwarz et al., NeurIPS 2020 | [github](https://github.com/autonomousvision/graf)  | [bibtex](./NeRF-and-Beyond.bib#L237-L243) <!---Schwarz20neurips_graf-->

--- a/citations/Block-NeRF
+++ b/citations/Block-NeRF
@@ -1,0 +1,6 @@
+@article{tancik2022blocknerf,
+  title={{Block-NeRF}: Scalable Large Scene Neural View Synthesis},
+  author={Matthew Tancik and Vincent Casser and Xinchen Yan and Sabeek Pradhan and Ben Mildenhall and Pratul Srinivasan and Jonathan T. Barron and Henrik Kretzschmar},
+  journal={arXiv},
+  year={2022}
+}


### PR DESCRIPTION
Block-NeRF is a variant of Neural Radiance Fields that can represent large-scale environments.